### PR TITLE
Add ability to set keys from config package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,8 +95,10 @@ func (c standardConfigManager) Get(key string) ([]byte, error) {
 // Set will put a key/value into the data store
 // and encode it with secconf
 func (c configManager) Set(key string, value []byte) error {
-	encodedValue, _ := secconf.Encode(value, bytes.NewBuffer(c.keystore))
-	err := c.store.Set(key, encodedValue)
+	encodedValue, err := secconf.Encode(value, bytes.NewBuffer(c.keystore))
+	if err == nil {
+		err = c.store.Set(key, encodedValue)
+	}
 	return err
 }
 


### PR DESCRIPTION
This pull request adds the Set() method to the ConfigManager interface so that you can set key/values in Go applications.
