### PR TITLE
Adding mock backend and tests

### DIFF
--- a/backend/mock/mock.go
+++ b/backend/mock/mock.go
@@ -12,21 +12,21 @@ var mockedStore map[string][]byte
 type Client struct{}
 
 func New(machines []string) (*Client, error) {
+	if mockedStore == nil {
+		mockedStore = make(map[string][]byte, 2)
+	}
 	return &Client{}, nil
 }
 
 func (c *Client) Get(key string) ([]byte, error) {
-	for k, v := range mockedStore {
-		if k == key {
-			return v, nil
-		}
+	if v, ok := mockedStore[key]; ok {
+		return v, nil
 	}
 	err := errors.New("Could not find key: " + key)
 	return nil, err
 }
 
 func (c *Client) Set(key string, value []byte) error {
-	mockedStore = make(map[string][]byte, 1)
 	mockedStore[key] = value
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -132,13 +132,8 @@ func (c configManager) Watch(key string, stop chan bool) <-chan *Response {
 					resp <- &Response{nil, r.Error}
 					continue
 				}
-				// If there is no value length, there's nothing to decode
-				if len(r.Value) != 0 {
-					value, err := secconf.Decode(r.Value, bytes.NewBuffer(c.keystore))
-					resp <- &Response{value, err}
-				} else {
-					resp <- &Response{[]byte{}, nil}
-				}
+				value, err := secconf.Decode(r.Value, bytes.NewBuffer(c.keystore))
+				resp <- &Response{value, err}
 			}
 		}
 	}()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -236,7 +236,7 @@ func Test_Get_AlternatePath_NoKey(t *testing.T) {
 }
 
 func Test_Watch_BasePath(t *testing.T) {
-	key := "foo"
+	key := "foo_enc"
 
 	store, err := mock.New([]string{})
 	if err != nil {


### PR DESCRIPTION
Goal of the PR: add config manager tests
This PR has the following changes:
- new backend `mock` that's used in unit tests
- new `config/config_test.go` file to test get / set / watch of config manager
- adds a generic `NewConfigManager` and `NewStandardConfigManager`. I think ideally people would use this instead and give it a store backend on creation, as the unit tests do. However, I kept the `NewEtcd...` and `NewConsul...` methods to not break backwards compatibility.

Let me know if there are any questions, thanks.
