### PR TITLE
Adding check for nil kv response to avoid runtime panics

### DIFF
--- a/backend/consul/consul.go
+++ b/backend/consul/consul.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -31,6 +32,9 @@ func (c *Client) Get(key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if kv == nil {
+		return nil, fmt.Errorf("Key ( %s ) was not found.", key)
+	}
 	return kv.Value, nil
 }
 
@@ -52,6 +56,9 @@ func (c *Client) Watch(key string, stop chan bool) <-chan *backend.Response {
 				WaitIndex: c.waitIndex,
 			}
 			keypair, meta, err := c.client.Get(key, &opts)
+			if keypair == nil && err == nil {
+				err = fmt.Errorf("Key ( %s ) was not found.", key)
+			}
 			if err != nil {
 				respChan <- &backend.Response{nil, err}
 				time.Sleep(time.Second * 5)


### PR DESCRIPTION
Fetching key value pairs would panic if the pair didn't exist, now it returns an error instead in both `Watch` and `Get`