### PR TITLE
Switch from deprecated github.com/armon/consul-api to official hashic…

### DIFF
--- a/backend/consul/consul.go
+++ b/backend/consul/consul.go
@@ -5,22 +5,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/xordataexchange/crypt/backend"
-
-	"github.com/armon/consul-api"
 )
 
 type Client struct {
-	client    *consulapi.KV
+	client    *api.KV
 	waitIndex uint64
 }
 
 func New(machines []string) (*Client, error) {
-	conf := consulapi.DefaultConfig()
+	conf := api.DefaultConfig()
 	if len(machines) > 0 {
 		conf.Address = machines[0]
 	}
-	client, err := consulapi.NewClient(conf)
+	client, err := api.NewClient(conf)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +54,7 @@ func (c *Client) List(key string) (backend.KVPairs, error) {
 
 func (c *Client) Set(key string, value []byte) error {
 	key = strings.TrimPrefix(key, "/")
-	kv := &consulapi.KVPair{
+	kv := &api.KVPair{
 		Key:   key,
 		Value: value,
 	}
@@ -67,7 +66,7 @@ func (c *Client) Watch(key string, stop chan bool) <-chan *backend.Response {
 	respChan := make(chan *backend.Response, 0)
 	go func() {
 		for {
-			opts := consulapi.QueryOptions{
+			opts := api.QueryOptions{
 				WaitIndex: c.waitIndex,
 			}
 			keypair, meta, err := c.client.Get(key, &opts)


### PR DESCRIPTION
…orp/consul/api

github.com/armon/consul-api is deprecated at has moved to the official consul repo at github.com/hashicorp/consul/api. I just switched that.
